### PR TITLE
Fix - Set isLeft to true to use leftIconColor on renderIcon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/react-native-elements",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "private": false,
   "description": "Platform Builders Shared Components Library For React Native",
   "keywords": [

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -281,7 +281,7 @@ const TextInput: FC<TextInputType> = ({
               inputRightPadding={inputRightPadding}
             >
               {borderedHeight && <FixedLabel>{label}</FixedLabel>}
-              {!!leftIconName && renderIcon(leftIconName)}
+              {!!leftIconName && renderIcon(leftIconName, true)}
               {renderTextInput(renderStatus)}
               {!!rightIconName && renderIcon(rightIconName)}
               {!leftIconName &&


### PR DESCRIPTION
## O que foi feito? 📝

Setar como true o parametro isLeft quando tiver o icone da esquerda, para que ele possa utilizar o leftIconColor.

## Screenshots ou GIFs 📸

![image](https://user-images.githubusercontent.com/88330804/155418134-8139cf4e-558b-4d96-b429-0e8e34bf91bb.png)

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ x ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

<!-- mobile -->

- [ x ] Testado no iOS
- [ ] Testado no Android
