### PR TITLE
Update snapshot date picker and dont skip this test

### DIFF
--- a/src/components/DatePicker/__tests__/DatePicker.spec.tsx
+++ b/src/components/DatePicker/__tests__/DatePicker.spec.tsx
@@ -108,7 +108,7 @@ describe('<DatePicker />', () => {
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
 
-  xit('should render datepicker with custom max date', () => {
+  it('should render datepicker with custom max date', () => {
     const wrapper = renderer.create(
       <ThemeProvider theme={theme}>
         <DatePicker id="testing" accessibility="" maxDate="30" />

--- a/src/components/DatePicker/__tests__/__snapshots__/DatePicker.spec.tsx.snap
+++ b/src/components/DatePicker/__tests__/__snapshots__/DatePicker.spec.tsx.snap
@@ -1546,7 +1546,7 @@ Array [
         Object {
           "color": "#ffffff",
           "lineHeight": 19,
-          "paddingBottom": 15,
+          "paddingBottom": 20,
         },
         Object {
           "fontSize": 18,
@@ -1834,7 +1834,8 @@ Array [
     style={
       Array [
         Object {
-          "height": 1,
+          "backgroundColor": "#ffffff",
+          "height": 0.5,
         },
       ]
     }


### PR DESCRIPTION
## O que foi feito? 📝

Atualizada snapshot do date picker e não skipando mais o teste

## Screenshots ou GIFs 📸

| Antes      | Depois |
| ------- | :---------: |
| <img width="332" alt="Screen Shot 2022-03-24 at 14 41 41" src="https://user-images.githubusercontent.com/7242605/159977557-0be77ebf-1648-4298-8dc1-f065de58ebf4.png"> |    <img width="285" alt="Screen Shot 2022-03-24 at 14 39 36" src="https://user-images.githubusercontent.com/7242605/159977459-4983eccf-421d-4cff-806c-94c55ae3259f.png">    |


## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [x] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

<!-- mobile -->

- [ ] Testado no iOS
- [ ] Testado no Android
