### PR TITLE
remove default style from attrs

### DIFF
--- a/src/components/PinInput/styles.ts
+++ b/src/components/PinInput/styles.ts
@@ -39,9 +39,7 @@ export const Wrapper = styled.View<WrapperProps>`
   flex-direction: row;
 `;
 
-export const PinCodeInput = styled(DefaultCodeInput).attrs((props) =>
-  defaultStyling(props),
-)``;
+export const PinCodeInput = styled(DefaultCodeInput)``;
 
 type IconProps = {
   contrast: boolean;


### PR DESCRIPTION
## O que foi feito? 📝

1. O default style no attrs estava sobrescrevendo o layout que passávamos  via prop

<!-- explicação do que foi feito -->

## Screenshots ou GIFs 📸

<!-- dica: use o KAP ou tire um print com cmd + shift + 5 -->

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [x] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

<!-- mobile -->

- [x] Testado no iOS
- [ ] Testado no Android
